### PR TITLE
Documentation for various kinds of "preferred" entities

### DIFF
--- a/src/lib/utils/datasetMetadata.ts
+++ b/src/lib/utils/datasetMetadata.ts
@@ -108,26 +108,26 @@ function findDatasetMetadata(
       );
     }
 
-    if (organismsTable == null || wdkReferencesTable == null) {
+    if (wdkReferencesTable == null) {
       throw new Error(
-        `In order to use this feature, each dataset record must have '${ORGANISMS_TABLE}' and '${WDK_REFERENCES_TABLE}' tables.`
+        `In order to use this feature, each dataset record must have a '${WDK_REFERENCES_TABLE}' tables.`
       );
     }
 
-    const organisms = organismsTable.reduce(
-      (memo, { [ORGANISM_ATTRIBUTE]: organism }) => {
-        if (typeof organism !== 'string') {
-          throw new Error(
-            `In order to use this feature, each row of the '${ORGANISMS_TABLE}' table must have a string-valued '${ORGANISM_ATTRIBUTE}' attribute.`
-          );
-        }
+    const organisms =
+      organismsTable == null
+        ? ['ALL']
+        : organismsTable.reduce((memo, { [ORGANISM_ATTRIBUTE]: organism }) => {
+            if (typeof organism !== 'string') {
+              throw new Error(
+                `In order to use this feature, each row of the '${ORGANISMS_TABLE}' table must have a string-valued '${ORGANISM_ATTRIBUTE}' attribute.`
+              );
+            }
 
-        memo.push(organism);
+            memo.push(organism);
 
-        return memo;
-      },
-      [] as string[]
-    );
+            return memo;
+          }, [] as string[]);
 
     const questions = wdkReferencesTable.reduce(
       (

--- a/src/lib/utils/preferredOrganisms.ts
+++ b/src/lib/utils/preferredOrganisms.ts
@@ -316,6 +316,14 @@ function findNewOrganisms(
   );
 }
 
+/**
+ * @param organismTree
+ * @param preferredOrganisms
+ * @returns A set consisting of all terms for preferred species.
+ *
+ * A species is considered to be "preferred" iff it has a child
+ * which is a preferred organism.
+ */
 function findPreferredSpecies(
   organismTree: TreeBoxVocabNode,
   preferredOrganisms: string[]
@@ -339,6 +347,24 @@ function findPreferredSpecies(
   );
 }
 
+/**
+ * @param questions
+ * @param datasetMetadata
+ * @param preferredOrganisms
+ * @returns A set consisting of all urlSegments for preferred questions.
+ *
+ * A dataset is considered to be "preferred" iff its Version WDK record table:
+ * 1. Has a row with a "preferred" organism attribute OR
+ * 2. Has a row with an organism attribute of "ALL" OR
+ * 3. Doesn't exist (because datasets with no Version table are assumed to apply to ALL organisms)
+ *
+ * A question is considered to be "preferred" iff:
+ * 1. It is associated with a "preferred" dataset OR
+ * 2. It is not associated with ANY dataset (because such questions are assumed to apply to ALL organisms)
+ *
+ * (A question X is said to be "associated with a dataset Y" iff
+ *  Y's References WDK record table has a "linkout" row to the question X)
+ */
 function findPreferredQuestions(
   questions: Question[],
   datasetMetadata: Map<string, DatasetMetadata>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0":
+"@babel/core@^7.0.0":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.9.tgz#6bae81a06d95f4d0dec5bb9d74bbc1f58babdcfe"
   integrity sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==


### PR DESCRIPTION
This PR adds some documentation for "preferred" species, datasets, and questions, and incidentally:

1. Updates the `yarn.lock` file
2. Updates the logic for "preferred" questions (to conform to https://github.com/VEuPathDB/ApiCommonWebsite/issues/96)