### PR TITLE
Bump web-app-preferred-organisms after upgrading dependences 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/preferred-organisms",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR upgrades the version of from v1.1.13 to  v1.1.14 following PR #8. @jernestmyers kindly reminded me that I forgot to patch the module in #8. 

To be clear, my changes from #8 would only live on [v1.1.14](https://github.com/VEuPathDB/web-app-preferred-organisms/tree/v1.1.14) and not [v1.1.13](https://github.com/VEuPathDB/web-app-preferred-organisms/tree/v1.1.13)